### PR TITLE
docs(config): fix typo

### DIFF
--- a/docs/config-file-options.md
+++ b/docs/config-file-options.md
@@ -409,7 +409,7 @@ Default: `False`
 
 ```json
 {
-  "publishStatusCommentOnSuccess": false
+  "publishStatusCommentOnAbort": false
 }
 ```
 


### PR DESCRIPTION
### Description

Fix typo in the config documentation.